### PR TITLE
[MINOR] allow optional oauth callback uri

### DIFF
--- a/src/OAuthSignRequest.js
+++ b/src/OAuthSignRequest.js
@@ -2,15 +2,17 @@ const { OAuth } = require('oauth');
 const getConfig = require('../config');
 const { getStatusText } = require('../src/HttpResponses');
 
-const doSignAndGet = async (linkToOpen, accessToken, accessTokenSecret) => {
+const doSignAndGet = async (linkToOpen, accessToken, accessTokenSecret, optionalAuthorizeCallbackUri) => {
   const config = await getConfig();
+  const authorizeCallbackUri = optionalAuthorizeCallbackUri || config.authorizeCallbackUri;
+
   const oAuthSession = new OAuth(
     config.firstLegUri,
     config.thirdLegUri,
     config.clientKey,
     config.clientSecret,
     config.oAuthVersion,
-    config.authorizeCallbackUri,
+    authorizeCallbackUri,
     config.oAuthSignatureMethod,
     config.oAuthNonceSize,
     config.oAuthCustomHeaders,
@@ -34,15 +36,17 @@ const doSignAndGet = async (linkToOpen, accessToken, accessTokenSecret) => {
   });
 };
 
-const doSignAndDelete = async (linkToOpen, accessToken, accessTokenSecret) => {
+const doSignAndDelete = async (linkToOpen, accessToken, accessTokenSecret, optionalAuthorizeCallbackUri) => {
   const config = await getConfig();
+  const authorizeCallbackUri = optionalAuthorizeCallbackUri || config.authorizeCallbackUri;
+
   const oAuthSession = new OAuth(
     config.firstLegUri,
     config.thirdLegUri,
     config.clientKey,
     config.clientSecret,
     config.oAuthVersion,
-    config.authorizeCallbackUri,
+    authorizeCallbackUri,
     config.oAuthSignatureMethod,
     config.oAuthNonceSize,
     config.oAuthCustomHeaders,
@@ -78,15 +82,18 @@ const doSignAndPost = async (
   accessTokenSecret,
   postBody,
   postBodyContentType,
+  optionalAuthorizeCallbackUri
 ) => {
   const config = await getConfig();
+  const authorizeCallbackUri = optionalAuthorizeCallbackUri || config.authorizeCallbackUri;
+
   const oAuthSession = new OAuth(
     config.firstLegUri,
     config.thirdLegUri,
     config.clientKey,
     config.clientSecret,
     config.oAuthVersion,
-    config.authorizeCallbackUri,
+    authorizeCallbackUri,
     config.oAuthSignatureMethod,
     config.oAuthNonceSize,
     config.oAuthCustomHeaders,

--- a/test/App.test.js
+++ b/test/App.test.js
@@ -2,32 +2,32 @@ describe('Lambda handlers', () => {
   afterEach(() => {
     jest.resetModules();
 
-    jest.mock("../src/publishSNSHelper");
+    jest.mock('../src/publishSNSHelper');
 
-    const { publishToSNSSuccess, publishToSNSUnsuccessfull } = require("../src/publishSNSHelper");
-    
+    const {publishToSNSSuccess, publishToSNSUnsuccessfull} = require('../src/publishSNSHelper');
+
     // these are supposed to return promises
     publishToSNSSuccess.mockResolvedValue(undefined);
-    publishToSNSUnsuccessfull.mockResolvedValue(undefined);  
+    publishToSNSUnsuccessfull.mockResolvedValue(undefined);
   });
 
   describe('OAuth First Leg Handler', () => {
     it('should be a function', () => {
-      const { firstLegHandler } = require('../app');
+      const {firstLegHandler} = require('../app');
 
       expect(firstLegHandler).toEqual(expect.any(Function));
     });
 
     it('should initialize oAuth with the correct parameters', async () => {
       const OAuth = require('oauth');
-      const config = await require("../config")();
+      const config = await require('../config')();
       const fakeGetOAuthRequestToken = jest.fn().mockImplementation(callback => callback());
 
       OAuth.OAuth = jest.fn().mockImplementation(() => ({
-        getOAuthRequestToken: fakeGetOAuthRequestToken,
+        getOAuthRequestToken: fakeGetOAuthRequestToken
       }));
 
-      const { firstLegHandler } = require('../app');
+      const {firstLegHandler} = require('../app');
 
       const event = chance.string();
       const context = chance.string();
@@ -46,7 +46,7 @@ describe('Lambda handlers', () => {
         config.authorizeCallbackUri,
         config.oAuthSignatureMethod,
         config.oAuthNonceSize,
-        config.oAuthCustomHeaders,
+        config.oAuthCustomHeaders
       ]);
     });
 
@@ -56,10 +56,10 @@ describe('Lambda handlers', () => {
       const fakeGetOAuthRequestToken = jest.fn().mockImplementation(callback => callback());
 
       OAuth.OAuth = jest.fn().mockImplementation(() => ({
-        getOAuthRequestToken: fakeGetOAuthRequestToken,
+        getOAuthRequestToken: fakeGetOAuthRequestToken
       }));
 
-      const { firstLegHandler } = require('../app');
+      const {firstLegHandler} = require('../app');
 
       const event = chance.string();
       const context = chance.string();
@@ -82,23 +82,23 @@ describe('Lambda handlers', () => {
       });
 
       OAuth.OAuth = jest.fn().mockImplementation(() => ({
-        getOAuthRequestToken: fakeGetOAuthRequestToken,
+        getOAuthRequestToken: fakeGetOAuthRequestToken
       }));
 
-      const { firstLegHandler } = require('../app');
+      const {firstLegHandler} = require('../app');
 
       const event = chance.string();
       const context = chance.string();
       const expectedResponse = {
         statusCode: 200,
         headers: {
-          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Origin': '*'
         },
         body: JSON.stringify({
           requestToken: fakeRequestToken,
-          requestTokenSecret: fakeRequestTokenSecret,
+          requestTokenSecret: fakeRequestTokenSecret
         }),
-        isBase64Encoded: false,
+        isBase64Encoded: false
       };
 
       expect(await firstLegHandler(event, context)).toMatchObject(expectedResponse);
@@ -116,10 +116,10 @@ describe('Lambda handlers', () => {
       });
 
       OAuth.OAuth = jest.fn().mockImplementation(() => ({
-        getOAuthRequestToken: fakeGetOAuthRequestToken,
+        getOAuthRequestToken: fakeGetOAuthRequestToken
       }));
 
-      const { firstLegHandler } = require('../app');
+      const {firstLegHandler} = require('../app');
 
       const event = chance.string();
       const context = chance.string();
@@ -127,10 +127,10 @@ describe('Lambda handlers', () => {
       const expectedResponse = {
         statusCode: 200,
         headers: {
-          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Origin': '*'
         },
         body: JSON.stringify(fakeError),
-        isBase64Encoded: false,
+        isBase64Encoded: false
       };
 
       expect(await firstLegHandler(event, context, callback)).toMatchObject(expectedResponse);
@@ -148,10 +148,10 @@ describe('Lambda handlers', () => {
       });
 
       OAuth.OAuth = jest.fn().mockImplementation(() => ({
-        getOAuthRequestToken: fakeGetOAuthRequestToken,
+        getOAuthRequestToken: fakeGetOAuthRequestToken
       }));
 
-      const { firstLegHandler } = require('../app');
+      const {firstLegHandler} = require('../app');
 
       const event = chance.string();
       const context = chance.string();
@@ -159,24 +159,23 @@ describe('Lambda handlers', () => {
 
       jest.mock('../src/publishSNSHelper');
 
-      const { publishToSNSSuccess } = require('../src/publishSNSHelper');
-
+      const {publishToSNSSuccess} = require('../src/publishSNSHelper');
 
       await firstLegHandler(event, context, callback);
 
       const response = {
         statusCode: 200,
         headers: {
-          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Origin': '*'
         },
         body: JSON.stringify({
           requestToken: fakeRequestToken,
-          requestTokenSecret: fakeRequestTokenSecret,
+          requestTokenSecret: fakeRequestTokenSecret
         }),
-        isBase64Encoded: false,
+        isBase64Encoded: false
       };
 
-      expect(publishToSNSSuccess).toHaveBeenCalledWith({ ...event, ...response });
+      expect(publishToSNSSuccess).toHaveBeenCalledWith({...event, ...response});
     });
 
     it('Should Send an unSuccessful Response To SNS Channel', async () => {
@@ -191,10 +190,10 @@ describe('Lambda handlers', () => {
       });
 
       OAuth.OAuth = jest.fn().mockImplementation(() => ({
-        getOAuthRequestToken: fakeGetOAuthRequestToken,
+        getOAuthRequestToken: fakeGetOAuthRequestToken
       }));
 
-      const { firstLegHandler } = require('../app');
+      const {firstLegHandler} = require('../app');
 
       const event = chance.string();
       const context = chance.string();
@@ -202,21 +201,20 @@ describe('Lambda handlers', () => {
       const response = {
         statusCode: 200,
         headers: {
-          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Origin': '*'
         },
         body: JSON.stringify(fakeError),
-        isBase64Encoded: false,
+        isBase64Encoded: false
       };
-
 
       jest.mock('../src/publishSNSHelper');
 
-      const { publishToSNSUnsuccessfull } = require('../src/publishSNSHelper');
+      const {publishToSNSUnsuccessfull} = require('../src/publishSNSHelper');
 
       await firstLegHandler(event, context, callback);
 
       expect(publishToSNSUnsuccessfull)
-        .toHaveBeenCalledWith({ ...event, ...response });
+        .toHaveBeenCalledWith({...event, ...response});
     });
   });
 
@@ -225,12 +223,12 @@ describe('Lambda handlers', () => {
       body: JSON.stringify({
         requestToken: chance.string(),
         requestTokenSecret: chance.string(),
-        verifier: chance.string(),
-      }),
+        verifier: chance.string()
+      })
     });
 
     it('should be a function', () => {
-      const { thirdLegHandler } = require('../app');
+      const {thirdLegHandler} = require('../app');
 
       expect(thirdLegHandler).toEqual(expect.any(Function));
     });
@@ -241,16 +239,16 @@ describe('Lambda handlers', () => {
       const mockGetOAuthAccessToken = jest.fn().mockImplementation((p1, p2, p3, callback) => callback());
 
       OAuth.OAuth = jest.fn().mockImplementation(() => ({
-        getOAuthAccessToken: mockGetOAuthAccessToken,
+        getOAuthAccessToken: mockGetOAuthAccessToken
       }));
 
-      const { thirdLegHandler } = require('../app');
+      const {thirdLegHandler} = require('../app');
 
       const event = generateFakeEvent();
       const {
         requestToken,
         requestTokenSecret,
-        verifier,
+        verifier
       } = JSON.parse(event.body);
 
       await thirdLegHandler(event);
@@ -269,18 +267,18 @@ describe('Lambda handlers', () => {
         });
 
       OAuth.OAuth = jest.fn().mockImplementation(() => ({
-        getOAuthAccessToken: mockGetOAuthAccessToken,
+        getOAuthAccessToken: mockGetOAuthAccessToken
       }));
 
       const context = undefined;
-      const { thirdLegHandler } = require('../app');
+      const {thirdLegHandler} = require('../app');
       const expectedResponse = {
         statusCode: 200,
         headers: {
-          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Origin': '*'
         },
         body: JSON.stringify(fakeError),
-        isBase64Encoded: false,
+        isBase64Encoded: false
       };
 
       expect(await thirdLegHandler(generateFakeEvent(), context)).toMatchObject(expectedResponse);
@@ -298,21 +296,21 @@ describe('Lambda handlers', () => {
         });
 
       OAuth.OAuth = jest.fn().mockImplementation(() => ({
-        getOAuthAccessToken: mockGetOAuthAccessToken,
+        getOAuthAccessToken: mockGetOAuthAccessToken
       }));
 
       const context = undefined;
-      const { thirdLegHandler } = require('../app');      
+      const {thirdLegHandler} = require('../app');
       const expectedResponse = {
         statusCode: 200,
         headers: {
-          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Origin': '*'
         },
         body: JSON.stringify({
           accessToken: fakeAccessToken,
-          accessTokenSecret: fakeAccessTokenSecret,
+          accessTokenSecret: fakeAccessTokenSecret
         }),
-        isBase64Encoded: false,
+        isBase64Encoded: false
       };
 
       expect(await thirdLegHandler(generateFakeEvent(), context)).toMatchObject(expectedResponse);
@@ -331,29 +329,29 @@ describe('Lambda handlers', () => {
         });
 
       OAuth.OAuth = jest.fn().mockImplementation(() => ({
-        getOAuthAccessToken: mockGetOAuthAccessToken,
+        getOAuthAccessToken: mockGetOAuthAccessToken
       }));
 
       const context = undefined;
-      const { thirdLegHandler } = require('../app');
-      const { publishToSNSSuccess } = require('../src/publishSNSHelper');
+      const {thirdLegHandler} = require('../app');
+      const {publishToSNSSuccess} = require('../src/publishSNSHelper');
 
       await thirdLegHandler(fakeEvent, context);
 
       const expectedResponse = {
         statusCode: 200,
         headers: {
-          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Origin': '*'
         },
         body: JSON.stringify({
           accessToken: fakeAccessToken,
-          accessTokenSecret: fakeAccessTokenSecret,
+          accessTokenSecret: fakeAccessTokenSecret
         }),
-        isBase64Encoded: false,
+        isBase64Encoded: false
       };
 
       expect(publishToSNSSuccess)
-        .toHaveBeenCalledWith({ ...fakeEvent, ...expectedResponse });
+        .toHaveBeenCalledWith({...fakeEvent, ...expectedResponse});
     });
 
     it('Should Send a unSuccessful Response To SNS Channel', async () => {
@@ -368,17 +366,17 @@ describe('Lambda handlers', () => {
         });
 
       OAuth.OAuth = jest.fn().mockImplementation(() => ({
-        getOAuthAccessToken: mockGetOAuthAccessToken,
+        getOAuthAccessToken: mockGetOAuthAccessToken
       }));
 
       const context = undefined;
       const fakeCallback = jest.fn();
 
-      const { thirdLegHandler } = require('../app');
+      const {thirdLegHandler} = require('../app');
 
       jest.mock('../src/publishSNSHelper');
 
-      const { publishToSNSUnsuccessfull } = require('../src/publishSNSHelper');
+      const {publishToSNSUnsuccessfull} = require('../src/publishSNSHelper');
       publishToSNSUnsuccessfull.mockResolvedValue(undefined);
 
       await thirdLegHandler(fakeEvent, context, fakeCallback);
@@ -386,14 +384,14 @@ describe('Lambda handlers', () => {
       const expectedResponse = {
         statusCode: 200,
         headers: {
-          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Origin': '*'
         },
         body: JSON.stringify(fakeError),
-        isBase64Encoded: false,
+        isBase64Encoded: false
       };
 
       expect(publishToSNSUnsuccessfull)
-        .toHaveBeenCalledWith({ ...fakeEvent, ...expectedResponse });
+        .toHaveBeenCalledWith({...fakeEvent, ...expectedResponse});
     });
   });
 
@@ -407,14 +405,14 @@ describe('Lambda handlers', () => {
         queryStringParameters: {
           url,
           accessToken,
-          accessTokenSecret,
-        },
+          accessTokenSecret
+        }
       };
 
       const OAuthSignRequest = require('../src/OAuthSignRequest');
 
       const fakeResponseData = {};
-      const numberOfResponseDataKeys = chance.natural({ min: 2, max: 5 });
+      const numberOfResponseDataKeys = chance.natural({min: 2, max: 5});
 
       for (let i = 0; i < numberOfResponseDataKeys; i += 1) {
         fakeResponseData[chance.string()] = chance.string();
@@ -424,18 +422,63 @@ describe('Lambda handlers', () => {
 
       OAuthSignRequest.doSignAndGet = jest.fn().mockResolvedValue(fakeResponseData);
 
-      const { oAuthSignRequestGet } = require('../app');
+      const {oAuthSignRequestGet} = require('../app');
 
       const responseData = await oAuthSignRequestGet(event);
 
-      expect(OAuthSignRequest.doSignAndGet).toBeCalledWith(url, accessToken, accessTokenSecret);
+      expect(OAuthSignRequest.doSignAndGet).toBeCalledWith(url, accessToken, accessTokenSecret, undefined);
       const response = {
         statusCode: fakeResponseData.status,
         headers: {
-          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Origin': '*'
         },
         body: JSON.stringify(fakeResponseData),
-        isBase64Encoded: false,
+        isBase64Encoded: false
+      };
+
+      expect(responseData).toEqual(response);
+    });
+
+    it('signs and gets the request, then returns the response when an oauth_callback query param is present', async () => {
+      const url = chance.url();
+      const accessToken = chance.string();
+      const accessTokenSecret = chance.string();
+      const oauth_callback = chance.string();
+
+      const event = {
+        queryStringParameters: {
+          url,
+          accessToken,
+          accessTokenSecret,
+          oauth_callback
+        }
+      };
+
+      const OAuthSignRequest = require('../src/OAuthSignRequest');
+
+      const fakeResponseData = {};
+      const numberOfResponseDataKeys = chance.natural({min: 2, max: 5});
+
+      for (let i = 0; i < numberOfResponseDataKeys; i += 1) {
+        fakeResponseData[chance.string()] = chance.string();
+      }
+
+      fakeResponseData.status = chance.natural();
+
+      OAuthSignRequest.doSignAndGet = jest.fn().mockResolvedValue(fakeResponseData);
+
+      const {oAuthSignRequestGet} = require('../app');
+
+      const responseData = await oAuthSignRequestGet(event);
+
+      expect(OAuthSignRequest.doSignAndGet).toBeCalledWith(url, accessToken, accessTokenSecret, oauth_callback);
+      const response = {
+        statusCode: fakeResponseData.status,
+        headers: {
+          'Access-Control-Allow-Origin': '*'
+        },
+        body: JSON.stringify(fakeResponseData),
+        isBase64Encoded: false
       };
 
       expect(responseData).toEqual(response);
@@ -445,7 +488,7 @@ describe('Lambda handlers', () => {
       const OAuthSignRequest = require('../src/OAuthSignRequest');
 
       const fakeError = {};
-      const numberOfErrorKeys = chance.natural({ min: 2, max: 5 });
+      const numberOfErrorKeys = chance.natural({min: 2, max: 5});
 
       for (let i = 0; i < numberOfErrorKeys; i += 1) {
         fakeError[chance.string()] = chance.string();
@@ -453,7 +496,7 @@ describe('Lambda handlers', () => {
 
       OAuthSignRequest.doSignAndGet = jest.fn().mockRejectedValue(fakeError);
 
-      const { oAuthSignRequestGet } = require('../app');
+      const {oAuthSignRequestGet} = require('../app');
 
       const url = chance.url();
       const accessToken = chance.string();
@@ -463,8 +506,8 @@ describe('Lambda handlers', () => {
         queryStringParameters: {
           url,
           accessToken,
-          accessTokenSecret,
-        },
+          accessTokenSecret
+        }
       };
 
       const returnedError = await oAuthSignRequestGet(fakeEvent);
@@ -472,10 +515,10 @@ describe('Lambda handlers', () => {
       const fakeErrorResponse = {
         statusCode: 502,
         headers: {
-          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Origin': '*'
         },
         body: JSON.stringify(fakeError),
-        isBase64Encoded: false,
+        isBase64Encoded: false
       };
 
       expect(returnedError).toEqual(fakeErrorResponse);
@@ -492,14 +535,14 @@ describe('Lambda handlers', () => {
         queryStringParameters: {
           url,
           accessToken,
-          accessTokenSecret,
-        },
+          accessTokenSecret
+        }
       };
 
       const OAuthSignRequest = require('../src/OAuthSignRequest');
 
       const fakeResponseData = {};
-      const numberOfResponseDataKeys = chance.natural({ min: 2, max: 5 });
+      const numberOfResponseDataKeys = chance.natural({min: 2, max: 5});
 
       for (let i = 0; i < numberOfResponseDataKeys; i += 1) {
         fakeResponseData[chance.string()] = chance.string();
@@ -509,18 +552,63 @@ describe('Lambda handlers', () => {
 
       OAuthSignRequest.doSignAndDelete = jest.fn().mockResolvedValue(fakeResponseData);
 
-      const { oAuthSignRequestDelete } = require('../app');
+      const {oAuthSignRequestDelete} = require('../app');
 
       const responseData = await oAuthSignRequestDelete(event);
 
-      expect(OAuthSignRequest.doSignAndDelete).toBeCalledWith(url, accessToken, accessTokenSecret);
+      expect(OAuthSignRequest.doSignAndDelete).toBeCalledWith(url, accessToken, accessTokenSecret, undefined);
       const response = {
         statusCode: fakeResponseData.status,
         headers: {
-          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Origin': '*'
         },
         body: JSON.stringify(fakeResponseData),
-        isBase64Encoded: false,
+        isBase64Encoded: false
+      };
+
+      expect(responseData).toEqual(response);
+    });
+
+    it('signs and deletes the request, then returns the response when an oauth_callback query param is present', async () => {
+      const url = chance.url();
+      const accessToken = chance.string();
+      const accessTokenSecret = chance.string();
+      const oauth_callback = chance.string();
+
+      const event = {
+        queryStringParameters: {
+          url,
+          accessToken,
+          accessTokenSecret,
+          oauth_callback
+        }
+      };
+
+      const OAuthSignRequest = require('../src/OAuthSignRequest');
+
+      const fakeResponseData = {};
+      const numberOfResponseDataKeys = chance.natural({min: 2, max: 5});
+
+      for (let i = 0; i < numberOfResponseDataKeys; i += 1) {
+        fakeResponseData[chance.string()] = chance.string();
+      }
+
+      fakeResponseData.status = chance.natural();
+
+      OAuthSignRequest.doSignAndDelete = jest.fn().mockResolvedValue(fakeResponseData);
+
+      const {oAuthSignRequestDelete} = require('../app');
+
+      const responseData = await oAuthSignRequestDelete(event);
+
+      expect(OAuthSignRequest.doSignAndDelete).toBeCalledWith(url, accessToken, accessTokenSecret, oauth_callback);
+      const response = {
+        statusCode: fakeResponseData.status,
+        headers: {
+          'Access-Control-Allow-Origin': '*'
+        },
+        body: JSON.stringify(fakeResponseData),
+        isBase64Encoded: false
       };
 
       expect(responseData).toEqual(response);
@@ -530,14 +618,14 @@ describe('Lambda handlers', () => {
       const OAuthSignRequest = require('../src/OAuthSignRequest');
       const fakeError = new Error(chance.string());
       OAuthSignRequest.doSignAndDelete = jest.fn().mockRejectedValue(fakeError);
-      const { oAuthSignRequestDelete } = require('../app');
+      const {oAuthSignRequestDelete} = require('../app');
 
       const fakeEvent = {
         queryStringParameters: {
           url: chance.url(),
           accessToken: chance.string(),
-          accessTokenSecret: chance.string(),
-        },
+          accessTokenSecret: chance.string()
+        }
       };
 
       const returnedError = await oAuthSignRequestDelete(fakeEvent);
@@ -545,10 +633,10 @@ describe('Lambda handlers', () => {
       const fakeErrorResponse = {
         statusCode: 502,
         headers: {
-          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Origin': '*'
         },
         body: JSON.stringify(fakeError),
-        isBase64Encoded: false,
+        isBase64Encoded: false
       };
 
       expect(returnedError).toEqual(fakeErrorResponse);
@@ -563,8 +651,8 @@ describe('Lambda handlers', () => {
         url: options.url || chance.url(),
         accessToken: options.accessToken || chance.string(),
         accessTokenSecret: options.accessTokenSecret || chance.string(),
-        data: options.data || chance.string(),
-      }),
+        data: options.data || chance.string()
+      })
     });
 
     beforeEach(() => {
@@ -572,7 +660,7 @@ describe('Lambda handlers', () => {
 
       OAuthSignRequest.doSignAndPost = jest.fn().mockResolvedValue(chance.string());
 
-      ({ oAuthSignRequestPost } = require('../app'));
+      ({oAuthSignRequestPost} = require('../app'));
     });
 
     it('should be a function', () => {
@@ -592,7 +680,7 @@ describe('Lambda handlers', () => {
 
       OAuthSignRequest.doSignAndPost = jest.fn().mockResolvedValue(chance.string());
 
-      ({ oAuthSignRequestPost } = require('../app'));
+      ({oAuthSignRequestPost} = require('../app'));
 
       const url = chance.url();
       const accessToken = chance.string();
@@ -603,14 +691,46 @@ describe('Lambda handlers', () => {
         url,
         accessToken,
         accessTokenSecret,
-        data,
+        data
       });
 
       await oAuthSignRequestPost(fakeEvent);
 
       expect(OAuthSignRequest.doSignAndPost)
         .toBeCalledWith(url, accessToken, accessTokenSecret,
-          JSON.stringify(data), expectedContentType);
+          JSON.stringify(data), expectedContentType, undefined);
+    });
+
+    it('calls doSignAndPost correctly when an oauth_callback query param is present', async () => {
+      jest.resetModules();
+
+      const OAuthSignRequest = require('../src/OAuthSignRequest');
+
+      OAuthSignRequest.doSignAndPost = jest.fn().mockResolvedValue(chance.string());
+
+      ({oAuthSignRequestPost} = require('../app'));
+
+      const url = chance.url();
+      const accessToken = chance.string();
+      const accessTokenSecret = chance.string();
+      const oauth_callback = chance.string();
+      const data = chance.string();
+      const expectedContentType = process.env.OAUTH_CUSTOM_HEADERS;
+      const fakeEvent = createFakeEvent({
+        url,
+        accessToken,
+        accessTokenSecret,
+        data
+      });
+      fakeEvent.queryStringParameters = {
+        oauth_callback
+      };
+
+      await oAuthSignRequestPost(fakeEvent);
+
+      expect(OAuthSignRequest.doSignAndPost)
+        .toBeCalledWith(url, accessToken, accessTokenSecret,
+          JSON.stringify(data), expectedContentType, oauth_callback);
     });
 
     it('returns the correct response when the post works', async () => {
@@ -618,31 +738,31 @@ describe('Lambda handlers', () => {
 
       const OAuthSignRequest = require('../src/OAuthSignRequest');
       const status = 200;
-      const fakeResponseData = JSON.stringify({ body: chance.string() });
+      const fakeResponseData = JSON.stringify({body: chance.string()});
       const fakeLocation = chance.string();
       const fakeResponse = {
         status,
         headers: {
           'Access-Control-Allow-Origin': '*',
-          location: fakeLocation,
+          location: fakeLocation
         },
         body: fakeResponseData,
-        isBase64Encoded: false,
+        isBase64Encoded: false
       };
 
       OAuthSignRequest.doSignAndPost = jest.fn().mockResolvedValue(fakeResponse);
 
-      ({ oAuthSignRequestPost } = require('../app'));
+      ({oAuthSignRequestPost} = require('../app'));
 
       const response = await oAuthSignRequestPost(createFakeEvent());
       const expectedResponse = {
         statusCode: status,
         headers: {
           'Access-Control-Allow-Origin': '*',
-          location: response.headers.location,
+          location: response.headers.location
         },
         body: JSON.stringify(fakeResponseData),
-        isBase64Encoded: false,
+        isBase64Encoded: false
       };
 
       expect(response).toEqual(expectedResponse);
@@ -654,7 +774,7 @@ describe('Lambda handlers', () => {
       const OAuthSignRequest = require('../src/OAuthSignRequest');
 
       const fakeError = {};
-      const numberOfErrorKeys = chance.natural({ min: 2, max: 5 });
+      const numberOfErrorKeys = chance.natural({min: 2, max: 5});
 
       for (let i = 0; i < numberOfErrorKeys; i += 1) {
         fakeError[chance.string()] = chance.string();
@@ -663,15 +783,15 @@ describe('Lambda handlers', () => {
       const fakeErrorResponse = {
         statusCode: 502,
         headers: {
-          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Origin': '*'
         },
         body: JSON.stringify(fakeError),
-        isBase64Encoded: false,
+        isBase64Encoded: false
       };
 
       OAuthSignRequest.doSignAndPost = jest.fn().mockRejectedValue(fakeError);
 
-      ({ oAuthSignRequestPost } = require('../app'));
+      ({oAuthSignRequestPost} = require('../app'));
 
       expect.assertions(1);
 


### PR DESCRIPTION
This PR is to allow an optional oauth_callback query param to be passed to the various endpoints found in the proxy.  This should be a minor bump in semver terms as it adds functionality and is backward compatible.  

This is needed for the upcoming ag-point-web application that will utilize the same proxy endpoint as the mobile.  Currently the mobile's callback uri is hardcoded to saimyjd://oauth.  This wont work for our web app.