### PR TITLE
More exact searching for params.json files in config file creation

### DIFF
--- a/deploy/create-config-files.sh
+++ b/deploy/create-config-files.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-for file in $(find deploy -type f -path *.params.json); do \
+for file in $(find deploy -type f -path "*.params.json"); do \
     envName=$(echo $file | xargs basename | sed "s/.params.json//"); \
     params=$(cat $file); \
     config="{}"; \


### PR DESCRIPTION
Adding quotes around the path search to prevent searching outside of the original source folder.

Previously this would find files anywhere in the project matching the `.params.json` which leads to issues when deploying the build.

Co-authored-by: Erik Rasmussen <erasmussen@sourceallies.com>