### PR TITLE
Test would fail asserts when getting a non httpstatus code

### DIFF
--- a/test/OAuthSignRequest.test.js
+++ b/test/OAuthSignRequest.test.js
@@ -519,11 +519,7 @@ describe("OAuth Sign Request", () => {
       const OAuth = require("oauth");
       const error = chance.string();
 
-      let statusCode = chance.natural({ min: 0, max: 500 });
-
-      while (statusCode > 200 && statusCode < 300) {
-        statusCode = chance.natural({ min: 0, max: 500 });
-      }
+      let statusCode = chance.natural({ min: 400, max: 505 });
 
       OAuth.OAuth = jest.fn().mockImplementation(() => ({
         post: (


### PR DESCRIPTION
Test can no longer get an error code below 400

Co-authored-by: Erik Rasmussen <erasmussen@sourceallies.com>